### PR TITLE
refactor all Debian compatible tasks

### DIFF
--- a/icinga2-ansible-add-hosts/handlers/main.yml
+++ b/icinga2-ansible-add-hosts/handlers/main.yml
@@ -2,11 +2,15 @@
 # handlers file for icinga2-ansible-add-hosts
 
 - name: restart icinga2
-  service: name=icinga2
-           state=restarted
-           enabled=yes
+  become: true
+  service:
+    name: icinga2
+    state: restarted
+    enabled: yes
 
 - name: reload icinga2
-  service: name=icinga2
-           state=reloaded
-           enabled=yes
+  become: true
+  service:
+    name: icinga2
+    state: reloaded
+    enabled: yes

--- a/icinga2-ansible-add-hosts/tasks/icinga2_add_hosts.yml
+++ b/icinga2-ansible-add-hosts/tasks/icinga2_add_hosts.yml
@@ -1,10 +1,12 @@
 ---
 - name: Copy Host Definitions
-  template: src=hosts_template.j2
-            dest={{ icinga2_hosts_dir }}/{{ hostvars[item]['ansible_fqdn'] }}.conf
-            owner=root
-            group=root
-            mode=0644
+  become: true
+  template:
+    src: hosts_template.j2
+    dest: "{{ icinga2_hosts_dir }}/{{ hostvars[item]['ansible_fqdn'] }}.conf"
+    owner: root
+    group: root
+    mode: 0644
   with_items: "{{ groups['all'] }}"
   notify:
-   - reload icinga2
+    - reload icinga2

--- a/icinga2-ansible-classic-ui/defaults/main.yml
+++ b/icinga2-ansible-classic-ui/defaults/main.yml
@@ -5,23 +5,23 @@ icinga2_classic_ui_passwd: "none"
 
 # Vars for Debian OS Family
 icinga2_classic_ui_pkg:
- - { package: "icinga2-classicui" }
- - { package: "python-passlib" }
+  - { package: "icinga2-classicui" }
+  - { package: "python-passlib" }
 
 htpasswd_deb: "/etc/icinga2/classicui/htpasswd.users"
 
 # Vars for RH OS Family
 icinga2_classic_ui_rpm:
- - { package: "icinga2-classicui-config" }
- - { package: "icinga-gui" }
- - { package: "python-passlib" }
+  - { package: "icinga2-classicui-config" }
+  - { package: "icinga-gui" }
+  - { package: "python-passlib" }
 
 htpasswd_rh: "/etc/icinga/passwd"
 
 # Vars for Gentoo OS Family
 icinga2_classic_ui_ebuilds:
- - { package: "icinga" }
- - { package: "passlib" }
+  - { package: "icinga" }
+  - { package: "passlib" }
 
 # Set which webserver to use, choice between apache2 and lighttpd, set to none if using
 # another webserver, but then you're on your own with configuring the webserver

--- a/icinga2-ansible-classic-ui/tasks/icinga2_classic_ui_Debian_install.yml
+++ b/icinga2-ansible-classic-ui/tasks/icinga2_classic_ui_Debian_install.yml
@@ -1,19 +1,22 @@
 ---
 - name: Install Icinga Classic UI on Debian OS family
-  apt: pkg={{ item.package }} 
-       state=latest
-       update_cache=yes
-       cache_valid_time=30
+  apt: 
+    pkg: "{{ item.package }}"
+    state: latest
+    update_cache: yes
+    cache_valid_time: 30
   with_items: icinga2_classic_ui_pkg
 
 - name: Configure a password for icingaadmin user
-  htpasswd: name=icingaadmin
-            state=present
-            path={{ htpasswd_deb }}
-            create=no
-            password={{ icinga2_classic_ui_passwd }}
-  notify: 
-   - restart apache2
+  htpasswd: 
+    name: icingaadmin
+    state: present
+    path: "{{ htpasswd_deb }}"
+    create: no
+    password: "{{ icinga2_classic_ui_passwd }}"
+  notify:
+    - restart apache2
 
 - name: Icinga Classic UI Installation finished (Debian)
-  debug: msg="Login at http://IP/icinga2-classicui with user icingaadmin and password {{ icinga2_classic_ui_passwd }}"
+  debug:
+    msg: "Login at http://IP/icinga2-classicui with user icingaadmin and password {{ icinga2_classic_ui_passwd }}"

--- a/icinga2-ansible-no-ui/handlers/main.yml
+++ b/icinga2-ansible-no-ui/handlers/main.yml
@@ -1,6 +1,15 @@
 ---
 # handlers file for icinga2-ansible-no-ui
 - name: restart icinga2
-  service: name=icinga2
-           state=restarted
-           enabled=yes
+  become: true
+  service:
+    name: icinga2
+    state: restarted
+    enabled: yes
+
+- name: start icinga2
+  become: true
+  service:
+    name: icinga2
+    state: started
+    enabled: yes

--- a/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
@@ -1,22 +1,26 @@
 ---
 - name: Install https for apt (Debian)
+  become: true
   apt:
     name: apt-transport-https
     state: present
 
 - name: Get Icinga2 Apt Key for Debian OS family
-  apt_key: 
+  become: true
+  apt_key:
     url: "{{ icinga2_key }}"
     state: present
 
   # Debian packages require additional packages which are provided by the
   # Debian Monitoring Project repository
 - name: Get Debmon Apt Key for Debian OS family (Debian)
+  become: true
   apt_key:
     url: "{{ icinga2_debmon_key }}"
     state: present
 
 - name: Get Icinga2 Apt Repos for Debian OS family
+  become: true
   apt_repository:
     repo: '{{ item.repo }}'
     update_cache: yes
@@ -26,12 +30,14 @@
   # Debian packages require additional packages which are provided by the
   # Debian Monitoring Project repository
 - name: Get Debmon Apt Repo for Debian OS family (Debian)
+  become: true
   apt_repository:
     repo: '{{ icinga2_debmon_repo }}'
     update_cache: yes
     state: present
 
 - name: Install Icinga2 on Debian OS family
+  become: true
   apt:
     pkg: "{{ item.package }}"
     update_cache: yes

--- a/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
@@ -1,38 +1,45 @@
 ---
 - name: Install https for apt (Debian)
-  apt: name=apt-transport-https state=present
+  apt:
+    name: apt-transport-https
+    state: present
 
 - name: Get Icinga2 Apt Key for Debian OS family
-  apt_key: url={{ icinga2_key }}
-           state=present
+  apt_key: 
+    url: "{{ icinga2_key }}"
+    state: present
 
   # Debian packages require additional packages which are provided by the
   # Debian Monitoring Project repository
 - name: Get Debmon Apt Key for Debian OS family (Debian)
-  apt_key: url={{ icinga2_debmon_key }}
-           state=present
+  apt_key:
+    url: "{{ icinga2_debmon_key }}"
+    state: present
 
 - name: Get Icinga2 Apt Repos for Debian OS family
-  apt_repository: repo='{{ item.repo }}'
-                  update_cache=yes
-                  state=present
+  apt_repository:
+    repo: '{{ item.repo }}'
+    update_cache: yes
+    state: present
   with_items: '{{ icinga2_deb_repos }}'
 
   # Debian packages require additional packages which are provided by the
   # Debian Monitoring Project repository
 - name: Get Debmon Apt Repo for Debian OS family (Debian)
-  apt_repository: repo='{{ icinga2_debmon_repo }}'
-                  update_cache=yes
-                  state=present
+  apt_repository:
+    repo: '{{ icinga2_debmon_repo }}'
+    update_cache: yes
+    state: present
 
 - name: Install Icinga2 on Debian OS family
-  apt: pkg={{ item.package }}
-       update_cache=yes
-       state=latest
-       install_recommends=no
+  apt:
+    pkg: "{{ item.package }}"
+    update_cache: yes
+    state: latest
+    install_recommends: no
   with_items: '{{ icinga2_pkg }}'
+  notify: start icinga2
 
+# TODO: call meta flush_handlers
 - name: Start Icinga2
-  service: name=icinga2
-           state=started
-           enabled=yes
+  meta: flush_handlers

--- a/icinga2-ansible-no-ui/tasks/icinga2_configure.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_configure.yml
@@ -1,22 +1,26 @@
 ---
 - name: Copy Main Icinga2 Configuration
-  template: src=icinga2.conf.j2
-            dest={{ icinga2_main_conf }}
-            backup=yes
-            owner=root
-            group=root
-            mode=0644
+  become: true
+  template:
+    src: icinga2.conf.j2
+    dest: "{{ icinga2_main_conf }}"
+    backup: yes
+    owner: root
+    group: root
+    mode: 0644
   when: "{{ icinga2_conf_global | default('') | length}}"
   notify:
-   - restart icinga2
+    - restart icinga2
 
 - name: Copy Check Commands Configuration
-  template: src=icinga2_check_commands.j2
-            dest={{ icinga2_conf_d }}/check_commands.conf
-            backup=yes
-            owner=root
-            group=root
-            mode=0644
+  become: true
+  template:
+    src: icinga2_check_commands.j2
+    dest: "{{ icinga2_conf_d }}/check_commands.conf"
+    backup: yes
+    owner: root
+    group: root
+    mode: 0644
   when: "{{ check_commands | default('') | length}}"
   notify:
-   - restart icinga2
+    - restart icinga2

--- a/icinga2-ansible-web-ui/handlers/main.yml
+++ b/icinga2-ansible-web-ui/handlers/main.yml
@@ -1,11 +1,15 @@
 ---
 # handlers file for icinga2-ansible-web-ui
 - name: restart icinga2
-  service: name=icinga2
-           state=restarted
-           enabled=yes
+  become: true
+  service:
+    name: icinga2
+    state: restarted
+    enabled: yes
 
 - name: restart httpd
-  service: name=httpd
-           state=restarted
-           enabled=yes
+  become: true
+  service:
+    name: httpd
+    state: restarted
+    enabled: yes

--- a/icinga2-ansible-web2-ui/handlers/main.yml
+++ b/icinga2-ansible-web2-ui/handlers/main.yml
@@ -1,6 +1,8 @@
 ---
 # handlers file for icinga2-ansible-web2-ui
 - name: restart icinga2
-  service: name=icinga2
-           state=restarted
-           enabled=yes
+  become: true
+  service:
+    name: icinga2
+    state: restarted
+    enabled: yes

--- a/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_Debian_install.yml
+++ b/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_Debian_install.yml
@@ -1,64 +1,85 @@
 ---
 - name: Install Mysql prerequisite
-  apt: name=python-mysqldb
+  become: true
+  apt:
+    name: python-mysqldb
+    state: present
 
 - name: Install Icinga2 IDO modules on Debian family
-  apt: name=icinga2-ido-mysql
-       state=latest
+  become: true
+  apt:
+    name: icinga2-ido-mysql
+    state: latest
 
 - name: Create a IDO Database for Icinga2
-  mysql_db: name={{ icinga2_db }}
-            state=present
+  become: true
+  mysql_db:
+    name: "{{ icinga2_db }}"
+    state: present
   register: icinga_ido_db
 
 - name: Create Icinga2 IDO Database User and configure Grants
-  mysql_user: name={{ icinga2_db_user }}
-              password={{ icinga2_db_pass }}
-              state=present
-              priv="{{ icinga2_db }}.*:GRANT,INSERT,SELECT,UPDATE,DELETE,DROP,CREATE VIEW,INDEX,EXECUTE"
+  become: true
+  mysql_user:
+    name: "{{ icinga2_db_user }}"
+    password: "{{ icinga2_db_pass }}"
+    state: present
+    priv: "{{ icinga2_db }}.*:GRANT,INSERT,SELECT,UPDATE,DELETE,DROP,CREATE VIEW,INDEX,EXECUTE"
 
 - name: Import the IDO Schema on Icinga Web Database (only once)
-  mysql_db: name={{ icinga2_db }}
-            state=import
-            target={{ icinga2_web_mysql_schema_debian }}
+  become: true
+  mysql_db:
+    name: "{{ icinga2_db }}"
+    state: import
+    target: "{{ icinga2_web_mysql_schema_debian }}"
   when: icinga_ido_db.changed == true
 
 - name: Configure Icinga2 Ido Mysql Feature
-  template: src=ido-mysql.conf.j2
-            dest={{ icinga2_ido_mysql_conf }}
-            backup=yes
-            owner=nagios
-            group=nagios
-            mode=0640
+  become: true
+  template:
+    src: ido-mysql.conf.j2
+    dest: "{{ icinga2_ido_mysql_conf }}"
+    backup: yes
+    owner: nagios
+    group: nagios
+    mode: 0640
 
 - name: Enable Icinga2 Ido Mysql Feature
   command: "icinga2 feature enable ido-mysql"
   register: features_result
   changed_when: "'for these changes to take effect' in features_result.stdout"
   notify:
-   - restart icinga2
+    - restart icinga2
 
 - name: Install Icinga Web2 on Debian family
-  apt: name={{ item.package }}
-       state=latest
+  become: true
+  apt:
+    name: "{{ item.package }}"
+    state: latest
   with_items: '{{ icinga2_web2_ui_deb }}'
   tags: icinga2-ansible-web2-ui-install
 
 - name: Create a Web Database for Icinga2
-  mysql_db: name={{ icinga2_web2_db }}
-            state=present
+  become: true
+  mysql_db:
+    name: "{{ icinga2_web2_db }}"
+    state: present
   register: icinga_web_db
 
 - name: Create Icinga2 Web Database User and configure Grants
-  mysql_user: name={{ icinga2_web2_db_user }}
-              password={{ icinga2_web2_db_pass }}
-              state=present
-              priv="{{ icinga2_web2_db }}.*:GRANT,INSERT,SELECT,UPDATE,DELETE,DROP,CREATE VIEW,INDEX,EXECUTE"
+  become: true
+  mysql_user:
+    name: "{{ icinga2_web2_db_user }}"
+    password: "{{ icinga2_web2_db_pass }}"
+    state: present
+    priv: "{{ icinga2_web2_db }}.*:GRANT,INSERT,SELECT,UPDATE,DELETE,DROP,CREATE VIEW,INDEX,EXECUTE"
 
 - name: Import the Web Schema on Icinga Web Database (only once)
-  mysql_db: name={{ icinga2_web2_db }}
-            state=import
-            target={{ icinga2_web2_mysql_schema_debian }}
+  become: true
+  mysql_db:
+    name: "{{ icinga2_web2_db }}"
+    state: import
+    target: "{{ icinga2_web2_mysql_schema_debian }}"
   when: icinga_web_db.changed == true
 
 - name: Define web server daemon package.
@@ -67,30 +88,47 @@
   when: web_server_daemon is not defined
 
 - name: Restart {{web_server_daemon}} and Icinga2 to Apply the Configuration
-  service: name={{ item }}
-           state=restarted
-           enabled=yes
+  become: true
+  service:
+    name: "{{ item }}"
+    state: restarted
+    enabled: yes
   with_items:
     - "{{web_server_daemon}}"
     - icinga2
 
 - name: Add user www-data to group icingaweb2
-  user: name=www-data
-        groups=icingaweb2
+  become: true
+  user:
+    name: www-data
+    groups: icingaweb2
 
 - name: Adjust Directory Owner and Group
-  file: path=/etc/icingaweb2/modules owner=www-data group=icingaweb2 mode=0755
-        state=directory
-        recurse=yes
+  become: true
+  file:
+    path: /etc/icingaweb2/modules 
+    owner: www-data 
+    group: icingaweb2 
+    mode: 0755
+    state: directory
+    recurse: yes
 
 - name: Create Directory Owner and Group
-  file: path=/etc/icingaweb2/modules/{{ item }} owner=www-data group=icingaweb2 mode=0755
-        state=directory
+  become: true
+  file:
+    path: "/etc/icingaweb2/modules/{{ item }}"
+    owner: www-data
+    group: icingaweb2
+    mode: 0755
+    state: directory
   with_items:
     - monitoring
     - translation
 
 - name: Icinga Web2 Installation finished (Debian)
-  debug: msg="Now generate a token with 'icingacli setup token create' and visit http://SERVERIP/icingaweb2/setup to continue the installation"
+  debug:
+    msg: |
+      Now generate a token with 'icingacli setup token create' 
+      and visit http://SERVERIP/icingaweb2/setup to continue the installation"
   tags: icinga2-ansible-web2-ui-install
 

--- a/icinga2-nrpe-agent/handlers/main.yml
+++ b/icinga2-nrpe-agent/handlers/main.yml
@@ -2,11 +2,14 @@
 # handlers file for icinga2-nrpe-agent
 
 - name: restart nrpe
-  service: name=nrpe
-           state=restarted 
-           enabled=yes
+  become: true
+  service:
+    name: nrpe
+    state: restarted 
+    enabled: yes
 
 - name: restart nagios-nrpe-server
-  service: name=nagios-nrpe-server
-           state=restarted 
-           enabled=yes
+  service:
+    name: nagios-nrpe-server
+    state: restarted 
+    enabled: yes

--- a/icinga2-nrpe-agent/tasks/icinga2_nrpe_agent_Debian.yml
+++ b/icinga2-nrpe-agent/tasks/icinga2_nrpe_agent_Debian.yml
@@ -1,20 +1,24 @@
 ---
 - name: Install Nrpe and Plugins
-  apt: pkg={{ item.package }} 
-       state=latest
-       update_cache=yes
-       install_recommends=no
+  become: true
+  apt:
+    pkg: "{{ item.package }} "
+    state: latest
+    update_cache: yes
+    install_recommends: no
   with_items: "{{ nrpe_agent_Debian }}"
   tags:
-   - nrpe_agent_install
+    - nrpe_agent_install
 
 - name: Copy Nrpe Configuration
-  template: src=nrpe.cfg.j2
-            dest={{ nrpe_agent_config }}
-            owner=root
-            group=root
-            mode=0644
-            backup=yes
+  become: true
+  template:
+    src: nrpe.cfg.j2
+    dest: "{{ nrpe_agent_config }}"
+    owner: root
+    group: root
+    mode: 0644
+    backup: yes
   notify:
    - restart nagios-nrpe-server
   tags:


### PR DESCRIPTION
* avoid using one-liner tasks that bulk view; instead spread them around
  with one carriage return and 2 tabs
* always use privilege escallation when triggering handlers
* always use privilege escallation when deploying icinga2 template files
  as they require changing user permission for the specific template file
* trigger handlers when needed via `meta: flush_handlers`

Resolves:
Related:
Signed-off-by: Daniel Andrei Minca <mandrei17@gmail.com>